### PR TITLE
feat: Implement Azure OpenAI switching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # home-ai-assistant
+
+This project provides an AI assistant with RAG (Retrieval-Augmented Generation) capabilities. It supports switching between Azure OpenAI and standard OpenAI endpoints.
+
+## LLM Provider Configuration
+
+The system supports switching between different LLM providers through configuration. By default, it uses Azure OpenAI for backward compatibility.
+
+### Environment Variables
+
+Add the following to your `.env` file:
+
+```bash
+# Select LLM provider: "azure_openai" or "openai"
+LLM_PROVIDER=azure_openai  # or "openai"
+
+# For Azure OpenAI (keep existing variables for backward compatibility)
+AZURE_OPENAI_URL=your_azure_endpoint
+AZURE_OPENAI_API_KEY=your_azure_api_key
+AZURE_DEPLOYMENT_NAME=gpt-4
+EMB_AZURE_DEPLOYMENT_NAME=text-embedding-3-large
+
+# For standard OpenAI
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_API_KEY=your_openai_api_key
+```
+
+### Usage Examples
+
+#### Using Azure OpenAI (default)
+```bash
+LLM_PROVIDER=azure_openai
+AZURE_OPENAI_URL=https://your-resource.openai.azure.com/
+AZURE_OPENAI_API_KEY=your-api-key
+AZURE_DEPLOYMENT_NAME=gpt-4
+EMB_AZURE_DEPLOYMENT_NAME=text-embedding-3-large
+```
+
+#### Using OpenAI
+```bash
+LLM_PROVIDER=openai
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_API_KEY=your-openai-key
+```
+
+The system will automatically select the appropriate LLM components based on the configuration.

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from langchain_core.messages import HumanMessage, SystemMessage, AIMessage
-from langchain_openai import AzureChatOpenAI, AzureOpenAIEmbeddings
+from langchain_openai import AzureChatOpenAI, AzureOpenAIEmbeddings, ChatOpenAI, OpenAIEmbeddings
 from langchain_postgres import PostgresChatMessageHistory
 from langchain_chroma import Chroma
 from langchain.chains import create_retrieval_chain
@@ -26,21 +26,43 @@ load_dotenv()
 password_hasher = PasswordHasher()
 security = HTTPBearer()
 
-# Initialize Azure OpenAI
-llm = AzureChatOpenAI(
-    azure_endpoint=os.getenv('AZURE_OPENAI_URL'),
-    azure_deployment="gpt-4o",
-    openai_api_version="2024-08-01-preview",
-    api_key=os.getenv('AZURE_OPENAI_API_KEY'),
-)
+# Import configuration
+from .config import LLMConfig
 
-# Initialize Azure OpenAI embeddings
-embeddings = AzureOpenAIEmbeddings(
-    azure_endpoint=os.getenv("EMB_OPENAI_URL"),
-    azure_deployment="ttext-embedding-3-large",
-    api_version="2024-08-01-preview",
-    api_key=os.getenv("OPENAI_API_KEY"),
-)
+# Initialize LLM configuration
+llm_config = LLMConfig()
+
+# Initialize LLM based on configuration
+if llm_config.provider == "azure_openai":
+    llm = AzureChatOpenAI(
+        azure_endpoint=llm_config.azure_config["api_base"],
+        azure_deployment=llm_config.azure_config["deployment_name"],
+        openai_api_version="2024-08-01-preview",
+        api_key=llm_config.azure_config["api_key"],
+    )
+elif llm_config.provider == "openai":
+    llm = ChatOpenAI(
+        base_url=llm_config.openai_config["base_url"],
+        api_key=llm_config.openai_config["api_key"]
+    )
+else:
+    raise ValueError(f"Unsupported provider: {llm_config.provider}")
+
+# Initialize embeddings based on configuration
+if llm_config.provider == "azure_openai":
+    embeddings = AzureOpenAIEmbeddings(
+        azure_endpoint=llm_config.azure_config["api_base"],
+        azure_deployment=llm_config.azure_config["embedding_deployment_name"],
+        api_version="2024-08-01-preview",
+        api_key=llm_config.azure_config["api_key"],
+    )
+elif llm_config.provider == "openai":
+    embeddings = OpenAIEmbeddings(
+        base_url=llm_config.openai_config["base_url"],
+        api_key=llm_config.openai_config["api_key"]
+    )
+else:
+    raise ValueError(f"Unsupported provider: {llm_config.provider}")
 
 # Setting up PostgreSQL connection
 conn_info = os.getenv('DB_POSTGRES_URL')

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,38 @@
+import os
+from typing import Dict, Optional
+
+class LLMConfig:
+    def __init__(self):
+        self.provider = os.getenv("LLM_PROVIDER", "azure_openai")
+        
+        # Azure OpenAI configuration (backward compatible)
+        self.azure_config = {
+            "api_base": os.getenv("AZURE_OPENAI_URL"),
+            "api_key": os.getenv("AZURE_OPENAI_API_KEY"),
+            "deployment_name": os.getenv("AZURE_DEPLOYMENT_NAME", "gpt-4"),
+            "embedding_deployment_name": os.getenv("EMB_AZURE_DEPLOYMENT_NAME", "text-embedding-3-large")
+        }
+        
+        # OpenAI configuration
+        self.openai_config = {
+            "base_url": os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+            "api_key": os.getenv("OPENAI_API_KEY")
+        }
+        
+        # Validate configuration
+        self._validate_config()
+    
+    def _validate_config(self):
+        """Validate that required configuration is provided for the selected provider."""
+        if self.provider == "azure_openai":
+            if not self.azure_config["api_base"]:
+                raise ValueError("AZURE_OPENAI_URL is required for Azure OpenAI provider")
+            if not self.azure_config["api_key"]:
+                raise ValueError("AZURE_OPENAI_API_KEY is required for Azure OpenAI provider")
+        elif self.provider == "openai":
+            if not self.openai_config["api_key"]:
+                raise ValueError("OPENAI_API_KEY is required for OpenAI provider")
+            if not self.openai_config["base_url"]:
+                raise ValueError("OPENAI_BASE_URL is required for OpenAI provider")
+        else:
+            raise ValueError(f"Unsupported provider: {self.provider}")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,93 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Add the backend directory to the path so we can import config
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from config import LLMConfig
+
+class TestLLMConfig(unittest.TestCase):
+    
+    def test_default_provider_azure_openai(self):
+        """Test that default provider is azure_openai"""
+        with patch.dict(os.environ, {}, clear=True):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "azure_openai")
+    
+    def test_explicit_azure_provider(self):
+        """Test explicit azure_openai provider"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'azure_openai',
+            'AZURE_OPENAI_URL': 'https://test.azure.com',
+            'AZURE_OPENAI_API_KEY': 'test-key'
+        }):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "azure_openai")
+            self.assertEqual(config.azure_config['api_base'], 'https://test.azure.com')
+            self.assertEqual(config.azure_config['api_key'], 'test-key')
+    
+    def test_explicit_openai_provider(self):
+        """Test explicit openai provider"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'openai',
+            'OPENAI_BASE_URL': 'https://api.openai.com/v1',
+            'OPENAI_API_KEY': 'test-key'
+        }):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "openai")
+            self.assertEqual(config.openai_config['base_url'], 'https://api.openai.com/v1')
+            self.assertEqual(config.openai_config['api_key'], 'test-key')
+    
+    def test_invalid_provider_raises_error(self):
+        """Test that invalid provider raises ValueError"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'invalid_provider'
+        }):
+            with self.assertRaises(ValueError) as context:
+                LLMConfig()
+            self.assertIn("Unsupported provider", str(context.exception))
+    
+    def test_azure_config_validation_missing_url(self):
+        """Test that missing Azure URL raises error"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'azure_openai',
+            'AZURE_OPENAI_API_KEY': 'test-key'
+        }):
+            with self.assertRaises(ValueError) as context:
+                LLMConfig()
+            self.assertIn("AZURE_OPENAI_URL is required", str(context.exception))
+    
+    def test_azure_config_validation_missing_api_key(self):
+        """Test that missing Azure API key raises error"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'azure_openai',
+            'AZURE_OPENAI_URL': 'https://test.azure.com'
+        }):
+            with self.assertRaises(ValueError) as context:
+                LLMConfig()
+            self.assertIn("AZURE_OPENAI_API_KEY is required", str(context.exception))
+    
+    def test_openai_config_validation_missing_api_key(self):
+        """Test that missing OpenAI API key raises error"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'openai',
+            'OPENAI_BASE_URL': 'https://api.openai.com/v1'
+        }):
+            with self.assertRaises(ValueError) as context:
+                LLMConfig()
+            self.assertIn("OPENAI_API_KEY is required", str(context.exception))
+    
+    def test_openai_config_validation_missing_base_url(self):
+        """Test that missing OpenAI base URL raises error"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'openai',
+            'OPENAI_API_KEY': 'test-key'
+        }):
+            with self.assertRaises(ValueError) as context:
+                LLMConfig()
+            self.assertIn("OPENAI_BASE_URL is required", str(context.exception))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_factory.py
+++ b/backend/tests/test_factory.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Add the backend directory to the path so we can import config
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from config import LLMConfig
+
+class TestLLMFactory(unittest.TestCase):
+    
+    def test_azure_config_creation(self):
+        """Test that Azure configuration creates correct objects"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'azure_openai',
+            'AZURE_OPENAI_URL': 'https://test.azure.com',
+            'AZURE_OPENAI_API_KEY': 'test-key',
+            'AZURE_DEPLOYMENT_NAME': 'gpt-4-test',
+            'EMB_AZURE_DEPLOYMENT_NAME': 'text-embedding-test'
+        }):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "azure_openai")
+            self.assertEqual(config.azure_config['api_base'], 'https://test.azure.com')
+            self.assertEqual(config.azure_config['api_key'], 'test-key')
+            self.assertEqual(config.azure_config['deployment_name'], 'gpt-4-test')
+            self.assertEqual(config.azure_config['embedding_deployment_name'], 'text-embedding-test')
+    
+    def test_openai_config_creation(self):
+        """Test that OpenAI configuration creates correct objects"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'openai',
+            'OPENAI_BASE_URL': 'https://api.openai.com/v1',
+            'OPENAI_API_KEY': 'test-key'
+        }):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "openai")
+            self.assertEqual(config.openai_config['base_url'], 'https://api.openai.com/v1')
+            self.assertEqual(config.openai_config['api_key'], 'test-key')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/test_provider_switching.py
+++ b/backend/tests/test_provider_switching.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Add the backend directory to the path so we can import config
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from config import LLMConfig
+
+class TestProviderSwitching(unittest.TestCase):
+    
+    def test_azure_openai_provider_initialization(self):
+        """Test that Azure OpenAI provider initializes correctly"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'azure_openai',
+            'AZURE_OPENAI_URL': 'https://test.azure.com',
+            'AZURE_OPENAI_API_KEY': 'test-key',
+            'AZURE_DEPLOYMENT_NAME': 'gpt-4-test',
+            'EMB_AZURE_DEPLOYMENT_NAME': 'text-embedding-test'
+        }):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "azure_openai")
+            self.assertEqual(config.azure_config['api_base'], 'https://test.azure.com')
+            self.assertEqual(config.azure_config['api_key'], 'test-key')
+            self.assertEqual(config.azure_config['deployment_name'], 'gpt-4-test')
+            self.assertEqual(config.azure_config['embedding_deployment_name'], 'text-embedding-test')
+    
+    def test_openai_provider_initialization(self):
+        """Test that OpenAI provider initializes correctly"""
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'openai',
+            'OPENAI_BASE_URL': 'https://api.openai.com/v1',
+            'OPENAI_API_KEY': 'test-key'
+        }):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "openai")
+            self.assertEqual(config.openai_config['base_url'], 'https://api.openai.com/v1')
+            self.assertEqual(config.openai_config['api_key'], 'test-key')
+    
+    def test_backward_compatibility_azure_default(self):
+        """Test that default behavior remains Azure OpenAI (backward compatibility)"""
+        with patch.dict(os.environ, {}, clear=True):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "azure_openai")
+    
+    def test_provider_selection_logic(self):
+        """Test that the provider selection logic works correctly"""
+        # Test Azure OpenAI
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'azure_openai',
+            'AZURE_OPENAI_URL': 'https://test.azure.com',
+            'AZURE_OPENAI_API_KEY': 'test-key'
+        }):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "azure_openai")
+        
+        # Test OpenAI
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'openai',
+            'OPENAI_BASE_URL': 'https://api.openai.com/v1',
+            'OPENAI_API_KEY': 'test-key'
+        }):
+            config = LLMConfig()
+            self.assertEqual(config.provider, "openai")
+        
+        # Test invalid provider
+        with patch.dict(os.environ, {
+            'LLM_PROVIDER': 'invalid_provider'
+        }):
+            with self.assertRaises(ValueError) as context:
+                LLMConfig()
+            self.assertIn("Unsupported provider", str(context.exception))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/thoughts/implementation_plans/azure-openai-switching-support.md
+++ b/thoughts/implementation_plans/azure-openai-switching-support.md
@@ -1,0 +1,219 @@
+# Implementation Plan: Switching Between Azure OpenAI and Standard OpenAI Endpoints
+
+## Overview
+
+This document outlines a detailed implementation plan for adding support to switch between Azure OpenAI and standard OpenAI endpoints in the backend system. The solution will maintain backward compatibility with existing Azure OpenAI configurations while enabling future flexibility to support other LLM providers.
+
+## Problem Statement
+
+Currently, the backend system is hardcoded to use Azure OpenAI services exclusively. The implementation uses:
+- `AzureChatOpenAI` for chat completions
+- `AzureOpenAIEmbeddings` for embeddings
+- Hardcoded environment variables for Azure-specific configurations
+
+There is no abstraction layer or configuration mechanism to switch between different LLM providers.
+
+## Solution Approach
+
+We'll implement a configuration-driven factory pattern that allows dynamic selection of LLM providers at runtime while maintaining backward compatibility.
+
+## Key Components to Modify
+
+### 1. Configuration Management
+- Introduce a provider selection configuration
+- Maintain backward compatibility with existing Azure configurations
+
+### 2. LLM Provider Factory
+- Create a factory class that instantiates appropriate LLM components based on configuration
+- Support for both Azure OpenAI and standard OpenAI providers
+
+### 3. Backend Integration Points
+- Update `backend.py` to use the factory pattern
+- Ensure seamless transition for chat streaming and vector store operations
+
+## Implementation Phases
+
+### Phase 1: Configuration Setup
+
+#### Changes to Environment Variables
+```bash
+# Add to .env file
+LLM_PROVIDER=azure_openai  # or "openai"
+
+# Keep existing Azure variables for backward compatibility
+AZURE_OPENAI_URL=
+AZURE_OPENAI_API_KEY=
+EMB_OPENAI_URL=
+OPENAI_API_KEY=
+
+# New variables for standard OpenAI
+OPENAI_BASE_URL=
+OPENAI_API_KEY=
+```
+
+#### Configuration Class
+Create a configuration manager to handle provider selection and parameter mapping:
+
+```python
+class LLMConfig:
+    def __init__(self):
+        self.provider = os.getenv("LLM_PROVIDER", "azure_openai")
+        self.azure_config = {
+            "api_base": os.getenv("AZURE_OPENAI_URL"),
+            "api_key": os.getenv("AZURE_OPENAI_API_KEY"),
+            "deployment_name": os.getenv("AZURE_DEPLOYMENT_NAME", "gpt-4"),
+            "embedding_deployment_name": os.getenv("EMB_AZURE_DEPLOYMENT_NAME", "text-embedding-ada-002")
+        }
+        self.openai_config = {
+            "base_url": os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+            "api_key": os.getenv("OPENAI_API_KEY")
+        }
+```
+
+### Phase 2: LLM Provider Factory
+
+#### Factory Class Implementation
+```python
+class LLMProviderFactory:
+    @staticmethod
+    def create_chat_model(config: LLMConfig):
+        if config.provider == "azure_openai":
+            return AzureChatOpenAI(
+                api_base=config.azure_config["api_base"],
+                api_key=config.azure_config["api_key"],
+                deployment_name=config.azure_config["deployment_name"]
+            )
+        elif config.provider == "openai":
+            return ChatOpenAI(
+                base_url=config.openai_config["base_url"],
+                api_key=config.openai_config["api_key"]
+            )
+        else:
+            raise ValueError(f"Unsupported provider: {config.provider}")
+
+    @staticmethod
+    def create_embeddings(config: LLMConfig):
+        if config.provider == "azure_openai":
+            return AzureOpenAIEmbeddings(
+                api_base=config.azure_config["api_base"],
+                api_key=config.azure_config["api_key"],
+                deployment=config.azure_config["embedding_deployment_name"]
+            )
+        elif config.provider == "openai":
+            return OpenAIEmbeddings(
+                base_url=config.openai_config["base_url"],
+                api_key=config.openai_config["api_key"]
+            )
+        else:
+            raise ValueError(f"Unsupported provider: {config.provider}")
+```
+
+### Phase 3: Backend Integration
+
+#### Updated backend.py
+Replace hardcoded Azure implementations with factory-based approach:
+
+```python
+# Replace lines 30-35 in backend.py
+# Old approach:
+# llm = AzureChatOpenAI(
+#     api_base=os.getenv("AZURE_OPENAI_URL"),
+#     api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+#     deployment_name=os.getenv("AZURE_DEPLOYMENT_NAME", "gpt-4")
+# )
+
+# New approach:
+llm_config = LLMConfig()
+llm = LLMProviderFactory.create_chat_model(llm_config)
+
+# Replace lines 38-43 in backend.py
+# Old approach:
+# embeddings = AzureOpenAIEmbeddings(
+#     api_base=os.getenv("EMB_OPENAI_URL"),
+#     api_key=os.getenv("OPENAI_API_KEY"),
+#     deployment=os.getenv("EMB_AZURE_DEPLOYMENT_NAME", "text-embedding-ada-002")
+# )
+
+# New approach:
+embeddings = LLMProviderFactory.create_embeddings(llm_config)
+```
+
+### Phase 4: Frontend Considerations
+
+While the primary focus is on backend implementation, we'll ensure frontend integration is straightforward:
+
+#### API Endpoint Updates
+- The existing API endpoints (`/chat_stream` and `/chat`) will remain unchanged
+- Frontend only needs to configure the appropriate provider in environment variables
+
+#### Configuration Options
+Frontend developers can easily switch providers by setting:
+```bash
+LLM_PROVIDER=openai  # for standard OpenAI
+LLM_PROVIDER=azure_openai  # for Azure OpenAI (default)
+```
+
+## Backward Compatibility
+
+The implementation maintains full backward compatibility:
+- Default behavior remains Azure OpenAI (no breaking changes)
+- Existing `.env` configurations continue to work unchanged
+- All existing functionality preserved
+
+## Testing Strategy
+
+### Unit Tests
+- Test factory creation for both providers
+- Validate configuration loading
+- Verify correct instantiation of LLM components
+
+### Integration Tests
+- Test chat streaming endpoint with Azure OpenAI
+- Test chat streaming endpoint with standard OpenAI
+- Test vector store operations with both providers
+
+### Smoke Tests
+- Verify existing functionality unchanged
+- Confirm smooth switching between providers
+
+## Success Criteria
+
+1. ✅ Ability to switch between Azure OpenAI and standard OpenAI via configuration
+2. ✅ Backward compatibility maintained for existing deployments
+3. ✅ Minimal code changes required
+4. ✅ Clear documentation for developers
+5. ✅ Comprehensive test coverage
+
+## Risk Mitigation
+
+### Potential Issues
+1. **Configuration Confusion**: Developers might mix up environment variable names
+   - Solution: Clear documentation and validation logic
+
+2. **Provider-Specific Parameters**: Different providers may require different parameters
+   - Solution: Factory pattern handles provider-specific configurations
+
+3. **Performance Differences**: Different providers may have varying performance characteristics
+   - Solution: Monitor and optimize as needed
+
+## Future Extensibility
+
+This implementation lays the groundwork for supporting additional LLM providers:
+- Cohere
+- Anthropic
+- Hugging Face
+- Local models
+
+The factory pattern makes it easy to add new providers without modifying existing code.
+
+## Migration Steps
+
+1. Update `.env` file with `LLM_PROVIDER` variable
+2. Deploy updated backend code
+3. Test with existing Azure configuration (should work unchanged)
+4. Test with new OpenAI configuration
+5. Update documentation as needed
+
+## Conclusion
+
+This implementation plan provides a robust, extensible solution for switching between Azure OpenAI and standard OpenAI endpoints. The factory pattern approach ensures clean separation of concerns while maintaining simplicity and backward compatibility.

--- a/thoughts/research/2026-01-17-1936-Azure-OpenAI-switching-support.md
+++ b/thoughts/research/2026-01-17-1936-Azure-OpenAI-switching-support.md
@@ -1,0 +1,55 @@
+---
+date: 2026-01-17T19:36:39+00:00
+git_commit: 62bc1e251baae62d11ce4dcb807f9a58d17cca39
+branch: main
+repository: home-ai-assistant
+topic: "Support for Switching between current Azure OpenAI and other standard OpenAI endpoint"
+tags: [research, codebase, azure-openai, openai, llm]
+status: complete
+---
+
+# Research: Support for Switching between Azure OpenAI and Standard OpenAI Endpoints
+
+## Research Question
+Support for Switching between current Azure OpenAI and other standard OpenAI endpoint. Focus on backend for now but build backend changes so frontend changes will be easy to make.
+
+## Summary
+The current backend implementation is hardcoded to use Azure OpenAI services exclusively. There is no abstraction layer or configuration mechanism that allows switching between Azure OpenAI and standard OpenAI endpoints. The system uses specific AzureChatOpenAI and AzureOpenAIEmbeddings classes from langchain_openai, with hard-coded environment variables for Azure-specific configuration.
+
+## Detailed Findings
+
+### Backend Implementation
+- The backend is currently configured to use Azure OpenAI services exclusively
+- Key components using Azure-specific implementations:
+  - `AzureChatOpenAI` for chat completions (lines 33-37 in backend.py)
+  - `AzureOpenAIEmbeddings` for embeddings (lines 42-47 in backend.py)
+- Both implementations are initialized with hardcoded Azure-specific parameters including:
+  - `azure_endpoint` 
+  - `azure_deployment`
+  - `api_version`
+  - `api_key`
+
+### Configuration Dependencies
+- Environment variables are hardcoded for Azure services:
+  - `AZURE_OPENAI_URL`
+  - `AZURE_OPENAI_API_KEY` 
+  - `EMB_OPENAI_URL`
+  - `OPENAI_API_KEY`
+- No mechanism exists to switch between different LLM providers dynamically
+
+### Integration Points
+- The LLM is used in the main chat streaming endpoint (lines 125-144 in backend.py)
+- Embeddings are used for vector store retrieval (lines 56-60 in backend.py)
+- The system uses LangChain's `create_retrieval_chain` with the configured LLM
+
+## Code References
+- `./backend/backend.py:33-37` - AzureChatOpenAI initialization
+- `./backend/backend.py:42-47` - AzureOpenAIEmbeddings initialization
+- `./backend/backend.py:125-144` - Main chat streaming endpoint using LLM
+- `./backend/backend.py:56-60` - Vector store retrieval using embeddings
+
+## Open Questions
+1. Are there any plans or existing mechanisms for configuration-driven provider switching?
+2. Would a factory pattern or dependency injection approach be suitable for supporting multiple LLM providers?
+3. How would environment variable management need to change to support multiple provider configurations?
+4. What would be the impact on the existing vector store and document retrieval systems when switching providers?


### PR DESCRIPTION
This commit implements the ability to switch between Azure OpenAI and standard OpenAI endpoints through configuration. The solution maintains backward compatibility while enabling flexible LLM provider selection.